### PR TITLE
Makefile: Fix: link with SystemC compiled with C++14

### DIFF
--- a/TPs/Makefile.common
+++ b/TPs/Makefile.common
@@ -35,7 +35,7 @@ CXX = g++
 CPPFLAGS  = -I$(SYSTEMC)/include 
 CPPFLAGS += -I$(ENSITLM) $(SDLCC)
 CPPFLAGS += -MMD -MP -MF $(basename $@).d
-CXXFLAGS = -O3 -g -Wall -Wextra -Winvalid-pch -Wno-unused-parameter --std=gnu++11
+CXXFLAGS = -O3 -g -Wall -Wextra -Winvalid-pch -Wno-unused-parameter
 # Used when using SDL, hence precompiled header use it, hence we have
 # to use it everywhere if we want PCH support:
 CXXFLAGS += -D_GNU_SOURCE=1 -D_REENTRANT


### PR DESCRIPTION
This patch fix a link error when the installed SystemC was not
compiled with the C++11 standard.

SystemC has a symbol associated with the std version, for example:
 - `sc_api_version_2_3_2_cxx201103L`, when compiled with std C++11
 - `sc_api_version_2_3_2_cxx201402L`, when compiled with std C++14

This difference make impossible to link the objects compiled using
std C++11 with the installed SystemC if compiled using another
standard.